### PR TITLE
Switch to latest Figwheel setup

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,30 +1,15 @@
 (defproject t3tr0s "0.1.0-SNAPSHOT"
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "0.0-3211"]
-                 [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
-                 ;; [com.cemerick/piggieback "0.1.3"]
-                 ;; [weasel "0.4.0-SNAPSHOT"]
-                 
-                 ]
+                 [org.clojure/clojurescript "1.7.122"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
 
-  :plugins [[lein-cljsbuild "1.0.5"]
-            [lein-figwheel "0.3.1"]
+  :plugins [[lein-figwheel "0.4.0"]
             [cider/cider-nrepl "0.9.1"]]
 
   :figwheel {:nrepl-port 7888}
   
   :source-paths ["src"]
-
-  ;; :cljsbuild { 
-  ;;   :builds {
-  ;;     :game {
-  ;;       :source-paths ["src/game"]
-  ;;       :compiler {
-  ;;         :output-to "public/game.js"
-  ;;         :output-dir "public/out"
-  ;;         :optimizations :whitespace}}
-  ;;    }}
 
   :target-path "target/%s"
   :clean-targets ^{:protect false} [:target-path "out"]
@@ -42,9 +27,4 @@
                         :compiler {:optimizations :advanced
                                    :output-to "target/js"}
                         :externs ["marked.min.js"]}]}
-  
-  ;; :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
-  ;; :injections [(require 'weasel.repl.websocket)
-  ;;              (def brepl #(cemerick.piggieback/cljs-repl :repl-env (weasel.repl.websocket/repl-env)))]
-
   )

--- a/project.clj
+++ b/project.clj
@@ -1,25 +1,15 @@
 (defproject t3tr0s "0.1.0-SNAPSHOT"
-
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.122"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
-
-  :plugins [[lein-figwheel "0.4.0"]
-            [cider/cider-nrepl "0.9.1"]]
-
+  :plugins [[lein-figwheel "0.4.0"]]
   :figwheel {:nrepl-port 7888}
-  
   :source-paths ["src"]
-
-  :target-path "target/%s"
-  :clean-targets ^{:protect false} [:target-path "out"]
+  :clean-targets ^{:protect false} [:target-path "public/out" "public/game.js"]
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src"]
                         :figwheel true
-                        :compiler {:main game.core}}
-                       {:id "prod"
-                        :source-paths ["src/game"]
-                        :compiler {:optimizations :advanced
-                                   :output-to "target/js"}
-                        :externs ["marked.min.js"]}]}
-  )
+                        :compiler {:main game.core
+                                   :asset-path "out"
+                                   :output-to "public/game.js"
+                                   :output-dir "public/out"}}]})

--- a/project.clj
+++ b/project.clj
@@ -16,12 +16,7 @@
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src"]
                         :figwheel true
-                        :compiler {
-                                   :main game.core
-                                   ;; :output-to "public/game.js"
-                                   ;; :output-dir "public/out"
-                                   ;; :optimizations :whitespace
-                                   }}
+                        :compiler {:main game.core}}
                        {:id "prod"
                         :source-paths ["src/game"]
                         :compiler {:optimizations :advanced

--- a/project.clj
+++ b/project.clj
@@ -1,27 +1,50 @@
 (defproject t3tr0s "0.1.0-SNAPSHOT"
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-2311"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [org.clojure/clojurescript "0.0-3211"]
                  [org.clojure/core.async "0.1.338.0-5c5012-alpha"]
-                 [com.cemerick/piggieback "0.1.3"]
-                 [weasel "0.4.0-SNAPSHOT"]]
+                 ;; [com.cemerick/piggieback "0.1.3"]
+                 ;; [weasel "0.4.0-SNAPSHOT"]
+                 
+                 ]
 
-  :plugins [[lein-cljsbuild "1.0.3"]]
+  :plugins [[lein-cljsbuild "1.0.5"]
+            [lein-figwheel "0.3.1"]
+            [cider/cider-nrepl "0.9.1"]]
 
+  :figwheel {:nrepl-port 7888}
+  
   :source-paths ["src"]
 
-  :cljsbuild { 
-    :builds {
-      :game {
-        :source-paths ["src/game"]
-        :compiler {
-          :output-to "public/game.js"
-          :output-dir "public/out"
-          :optimizations :whitespace}}
-     }}
+  ;; :cljsbuild { 
+  ;;   :builds {
+  ;;     :game {
+  ;;       :source-paths ["src/game"]
+  ;;       :compiler {
+  ;;         :output-to "public/game.js"
+  ;;         :output-dir "public/out"
+  ;;         :optimizations :whitespace}}
+  ;;    }}
 
-  :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
-  :injections [(require 'weasel.repl.websocket)
-               (def brepl #(cemerick.piggieback/cljs-repl :repl-env (weasel.repl.websocket/repl-env)))]
+  :target-path "target/%s"
+  :clean-targets ^{:protect false} [:target-path "out"]
+  :cljsbuild {:builds [{:id "dev"
+                        :source-paths ["src"]
+                        :figwheel true
+                        :compiler {
+                                   :main game.core
+                                   ;; :output-to "public/game.js"
+                                   ;; :output-dir "public/out"
+                                   ;; :optimizations :whitespace
+                                   }}
+                       {:id "prod"
+                        :source-paths ["src/game"]
+                        :compiler {:optimizations :advanced
+                                   :output-to "target/js"}
+                        :externs ["marked.min.js"]}]}
+  
+  ;; :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
+  ;; :injections [(require 'weasel.repl.websocket)
+  ;;              (def brepl #(cemerick.piggieback/cljs-repl :repl-env (weasel.repl.websocket/repl-env)))]
 
   )

--- a/src/game/core.cljs
+++ b/src/game/core.cljs
@@ -2,7 +2,7 @@
   (:require-macros
     [cljs.core.async.macros :refer [go go-loop alt!]])
   (:require
-    [weasel.repl :as repl]
+    ;; [weasel.repl :as repl]
     [cljs.reader :refer [read-string]]
     [game.board :refer [piece-fits?
                         rotate-piece
@@ -393,7 +393,7 @@
 
 (defn init []
 
-  (repl/connect "ws://localhost:9001")
+  ;; (repl/connect "ws://localhost:9001")
 
   (init-state!)
 

--- a/src/game/core.cljs
+++ b/src/game/core.cljs
@@ -2,7 +2,6 @@
   (:require-macros
     [cljs.core.async.macros :refer [go go-loop alt!]])
   (:require
-    ;; [weasel.repl :as repl]
     [cljs.reader :refer [read-string]]
     [game.board :refer [piece-fits?
                         rotate-piece
@@ -392,8 +391,6 @@
 ;;------------------------------------------------------------
 
 (defn init []
-
-  ;; (repl/connect "ws://localhost:9001")
 
   (init-state!)
 

--- a/src/game/core.cljs
+++ b/src/game/core.cljs
@@ -1,4 +1,4 @@
-(ns game.core
+(ns ^:figwheel-always game.core
   (:require-macros
     [cljs.core.async.macros :refer [go go-loop alt!]])
   (:require


### PR DESCRIPTION
In the spirit of repo, I switched to the simplest (and latest) Figwheel setup that I could. I left nREPL deps and middleware out, in order to keep it simple.